### PR TITLE
Fix integration docker compose files with new repo structure

### DIFF
--- a/integration/docker-compose-devel.yml
+++ b/integration/docker-compose-devel.yml
@@ -19,11 +19,12 @@ services:
       - 5432
   request:
     build: 
-      context: https://github.com/CSCfi/swift-sharing-request.git#devel
+      context: https://github.com/CSCfi/swift-browser-ui.git#devel
+      dockerfile: dockerfiles/Dockerfile-request
     image: swift-sharing-request-docker:devel
     deploy:
       mode: replicated
-      replicas: 4
+      replicas: 1
       update_config:
         parallelism: 2
         delay: 10s
@@ -39,11 +40,12 @@ services:
       - 9091:9091
   sharing:
     build: 
-      context: https://github.com/CSCfi/swift-x-account-sharing.git#devel
+      context: https://github.com/CSCfi/swift-browser-ui.git#devel
+      dockerfile: dockerfiles/Dockerfile-sharing
     image: swift-x-account-sharing-docker:devel
     deploy:
       mode: replicated
-      replicas: 4
+      replicas: 1
       update_config:
         parallelism: 2
         delay: 10s
@@ -59,11 +61,12 @@ services:
       - 9090:9090
   download:
     build:
-      context: https://github.com/CSCfi/swiftui-upload-runner.git#devel
+      context: https://github.com/CSCfi/swift-browser-ui.git#devel
+      dockerfile: dockerfiles/Dockerfile-runner
     image: swiftui-upload-runner-docker:devel
     deploy:
       mode: replicated
-      replicas: 4
+      replicas: 1
       update_config:
         parallelism: 2
         delay: 10s
@@ -80,7 +83,7 @@ services:
   ui:
     build: 
       context: https://github.com/CSCfi/swift-browser-ui.git#devel
-      dockerfile: Dockerfile-Devel
+      dockerfile: dockerfiles/Dockerfile-ui-devel
     image: swift-browser-ui:devel
     deploy:
       mode: replicated

--- a/integration/docker-compose-production.yml
+++ b/integration/docker-compose-production.yml
@@ -13,14 +13,16 @@ services:
       - 5432
   download:
     build:
-      context: https://github.com/CSCfi/swiftui-upload-runner.git#v0.1.1
-    image: swiftui-upload-runner-docker:prouction
+      context: https://github.com/CSCfi/swift-browser-ui.git
+      dockerfile: dockerfiles/Dockerfile-runner
+    image: swiftui-upload-runner-docker:production
     env_file: ./envs.sh
     ports:
       - 9092:9092
   request:
     build: 
-      context: https://github.com/CSCfi/swift-sharing-request.git#v0.4.2
+      context: https://github.com/CSCfi/swift-browser-ui.git
+      dockerfile: dockerfiles/Dockerfile-request
     image: swift-sharing-request-docker:production
     links:
       - "db:database"
@@ -29,7 +31,8 @@ services:
       - 9091:9091
   sharing:
     build: 
-      context: https://github.com/CSCfi/swift-x-account-sharing.git#v0.5.3
+      context: https://github.com/CSCfi/swift-browser-ui.git
+      dockerfile: dockerfiles/Dockerfile-sharing
     image: swift-x-account-sharing-docker:production
     links:
       - "db:database"
@@ -38,7 +41,8 @@ services:
       - 9090:9090
   ui:
     build: 
-      context: https://github.com/CSCfi/swift-browser-ui.git#v1.0.0-rc2
+      context: https://github.com/CSCfi/swift-browser-ui.git
+      dockerfile: dockerfiles/Dockerfile-ui
     image: swift-browser-ui:production
     env_file: ./envs.sh
     ports:


### PR DESCRIPTION
### Description
All project services were merged under the same repository `swift-browser-ui` to ease development, along with their respective dockerfiles. The docker compose files have been altered to work with this new repo structure.

### Changes
* Use `swift-browser-ui` repo for building all services

